### PR TITLE
Fixed typo preventing using paid subscription key

### DIFF
--- a/oxford/vision.py
+++ b/oxford/vision.py
@@ -2,9 +2,9 @@ import re
 
 from .base import Base
 
-_analyzeUrl = 'https://api.projectoxford.ai/vision/v1/analyses'
-_thumbnailUrl = 'https://api.projectoxford.ai/vision/v1/thumbnails'
-_ocrUrl = 'https://api.projectoxford.ai/vision/v1/ocr'
+_analyzeUrl = 'https://api.projectoxford.ai/vision/v1.0/analyses'
+_thumbnailUrl = 'https://api.projectoxford.ai/vision/v1.0/thumbnails'
+_ocrUrl = 'https://api.projectoxford.ai/vision/v1.0/ocr'
 
 
 class Vision(Base):


### PR DESCRIPTION
This module worked fine with free keys but for my paid subscription key I got this error:
Exception: status 401: { "statusCode": 401, 
"message": "Access denied due to invalid subscription key. 
Make sure to provide a valid key for an active subscription." }
Changing "v1" by "v1.0" fixed it.